### PR TITLE
Add header to messages

### DIFF
--- a/msg/BodyPosture.msg
+++ b/msg/BodyPosture.msg
@@ -1,4 +1,5 @@
 # Describes the general body posture in a symbolic manner.
+Header header
 
 uint8 STANDING = 1
 uint8 SITTING = 2

--- a/msg/EngagementLevel.msg
+++ b/msg/EngagementLevel.msg
@@ -3,7 +3,8 @@
 # to access to the engagement level of a detected human. 
 # It will output one of the five following levels: unknown, disengaged, 
 # engaging, engaged and disengaging.
-  
+Header header  
+
 # unknown: no information is provided about the engagement level 
 uint8 UNKNOWN=0
 # disengaged: the human has not looked in the direction of the robot

--- a/msg/Expression.msg
+++ b/msg/Expression.msg
@@ -1,5 +1,6 @@
 # Represents a human facial expression, either in a categorical way, or
 # using the valence/arousal model of emotions
+Header header
 
 # the list of expressions is based on Chambers MSc thesis, Bristol Robotics Lab 2020, and includes the six basic emotions in Eckman's model.
 #

--- a/msg/FacialLandmarks.msg
+++ b/msg/FacialLandmarks.msg
@@ -2,6 +2,7 @@
 # (0, 0) is at top-left corner of image
 # Features' coordinates are expressed in normalised pixel coordinates 
 # (in the range [0., 1.]), from the top-left corner.
+Header header
 
 # Facial landmarks naming
 # Follows dlib and OpenPose convention

--- a/msg/Gaze.msg
+++ b/msg/Gaze.msg
@@ -3,6 +3,7 @@
 #
 # If the sender or receiver IDs are empty, it means that the gaze respectively
 # originates or is targeted to the robot itself.
+Header header
 
 string sender
 string receiver

--- a/msg/Gesture.msg
+++ b/msg/Gesture.msg
@@ -1,4 +1,5 @@
 # Describes body language/attitude/gesture detected from a body.
+Header header
 
 # Additional gestures might be added in the future, please open
 # issues/pull requests to suggest new ones.

--- a/msg/Group.msg
+++ b/msg/Group.msg
@@ -1,3 +1,4 @@
+Header header
 
 string group_id
 

--- a/msg/SoftBiometrics.msg
+++ b/msg/SoftBiometrics.msg
@@ -1,4 +1,5 @@
 # This message describes soft biometrics (age and gender)
+Header header
 
 uint8 age
 float32 age_confidence


### PR DESCRIPTION
This PR adds a field of type `Header` to `SoftBiometrics` and `PointOfInterest2D` messages to ensure they are compatible with synchronisation facilities provided by ROS