### PR TITLE
add HRI IdHeader to all relevant ROS4HRI messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,29 +4,36 @@ project(hri_msgs)
 find_package(catkin REQUIRED COMPONENTS
   message_generation
   sensor_msgs
+  audio_common_msgs
 )
 
 add_message_files(
     DIRECTORY msg
     FILES
+    AudioDataIdStamped.msg
     AudioFeatures.msg
     BodyPosture.msg
+    BoolIdStamped.msg
     EngagementLevel.msg
     Expression.msg
     FacialActionUnits.msg
     FacialLandmarks.msg
+    Float32IdStamped.msg
     Gaze.msg
     Gesture.msg
     Group.msg
+    IdHeader.msg
     IdsList.msg
     IdsMatch.msg
+    ImageIdStamped.msg
+    JointStateIdStamped.msg
     LiveSpeech.msg
     NormalizedPointOfInterest2D.msg
     NormalizedPointOfInterest2DStamped.msg
     NormalizedRegionOfInterest2D.msg
     Skeleton2D.msg
     SoftBiometrics.msg
-
+    StringIdStamped.msg
     # list here the .msg files
 )
 
@@ -34,6 +41,7 @@ add_message_files(
 generate_messages(
     DEPENDENCIES
     sensor_msgs
+    audio_common_msgs
 )
 
 catkin_package(

--- a/msg/AudioDataIdStamped.msg
+++ b/msg/AudioDataIdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+audio_common_msgs/AudioData data

--- a/msg/AudioFeatures.msg
+++ b/msg/AudioFeatures.msg
@@ -6,6 +6,8 @@
 # They can be extract using the OpenSMILE toolkit with the present
 # IS09_emotion.conf
 
+IdHeader header
+
 float32 ZCR # zero-crossing rate from the time signal
 float32 RMS # root mean square frame energy
 float32 pitch # pitch frequency (normalised to 500 Hz)

--- a/msg/BodyPosture.msg
+++ b/msg/BodyPosture.msg
@@ -1,5 +1,5 @@
 # Describes the general body posture in a symbolic manner.
-Header header
+IdHeader header
 
 uint8 STANDING = 1
 uint8 SITTING = 2

--- a/msg/BoolIdStamped.msg
+++ b/msg/BoolIdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+bool data

--- a/msg/EngagementLevel.msg
+++ b/msg/EngagementLevel.msg
@@ -3,7 +3,7 @@
 # to access to the engagement level of a detected human. 
 # It will output one of the five following levels: unknown, disengaged, 
 # engaging, engaged and disengaging.
-Header header  
+IdHeader header  
 
 # unknown: no information is provided about the engagement level 
 uint8 UNKNOWN=0

--- a/msg/Expression.msg
+++ b/msg/Expression.msg
@@ -1,6 +1,6 @@
 # Represents a human facial expression, either in a categorical way, or
 # using the valence/arousal model of emotions
-Header header
+IdHeader header
 
 # the list of expressions is based on Chambers MSc thesis, Bristol Robotics Lab 2020, and includes the six basic emotions in Eckman's model.
 #

--- a/msg/FacialActionUnits.msg
+++ b/msg/FacialActionUnits.msg
@@ -1,8 +1,7 @@
 # This message the intensity of each actions unit (AU), with their confidence, for a specific face.
 #
 # It follows the naming convention of the  Facial Action Coding System (FACS) developed by Ekman.
-
-Header header
+IdHeader header
 
 # List taken from https://en.wikipedia.org/wiki/Facial_Action_Coding_System
 

--- a/msg/FacialLandmarks.msg
+++ b/msg/FacialLandmarks.msg
@@ -2,7 +2,7 @@
 # (0, 0) is at top-left corner of image
 # Features' coordinates are expressed in normalised pixel coordinates 
 # (in the range [0., 1.]), from the top-left corner.
-Header header
+IdHeader header
 
 # Facial landmarks naming
 # Follows dlib and OpenPose convention

--- a/msg/Float32IdStamped.msg
+++ b/msg/Float32IdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+float32 data

--- a/msg/Gesture.msg
+++ b/msg/Gesture.msg
@@ -1,5 +1,5 @@
 # Describes body language/attitude/gesture detected from a body.
-Header header
+IdHeader header
 
 # Additional gestures might be added in the future, please open
 # issues/pull requests to suggest new ones.

--- a/msg/IdHeader.msg
+++ b/msg/IdHeader.msg
@@ -1,0 +1,6 @@
+time stamp
+string frame_id
+# topic of the data source from which the content of the message is extracted or derived
+string data_source
+# identifier attaching the content of the message to its reference resource (eg, its 'owner')
+string id

--- a/msg/ImageIdStamped.msg
+++ b/msg/ImageIdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+sensor_msgs/Image image

--- a/msg/JointStateIdStamped.msg
+++ b/msg/JointStateIdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+sensor_msgs/JointState joint_state

--- a/msg/LiveSpeech.msg
+++ b/msg/LiveSpeech.msg
@@ -1,8 +1,7 @@
 # This message encodes the live result of a speech recognition process.
 # A series of incremental results might be provided, until a final recognition
 # hypothesis is returned.
-
-Header header
+IdHeader header
 
 string incremental # incremental recognition results
 string final # final recognised text

--- a/msg/NormalizedRegionOfInterest2D.msg
+++ b/msg/NormalizedRegionOfInterest2D.msg
@@ -3,7 +3,7 @@
 # The (xmin, ymin) tuple stores the top-leftmost coordinates of the ROI, while (xmax, ymax) represents the
 # bottom-rightmost coordinates.
 # c is a confidence level (between 0. and 1.) associated to that ROI
-Header header # Header timestamp should be acquisition time of the original image
+IdHeader header # Header timestamp should be acquisition time of the original image
 float32 xmin
 float32 ymin
 float32 xmax

--- a/msg/Skeleton2D.msg
+++ b/msg/Skeleton2D.msg
@@ -1,7 +1,6 @@
 # This message contains a list of skeletal keypoints 
 # (0, 0) is at top-left corner of image
-
-Header header        # Header timestamp should be acquisition time of the original image
+IdHeader header        # Header timestamp should be acquisition time of the original image
 
 # skeletal key Points naming
 # Follows OpenPose coco model convention

--- a/msg/SoftBiometrics.msg
+++ b/msg/SoftBiometrics.msg
@@ -1,5 +1,5 @@
 # This message describes soft biometrics (age and gender)
-Header header
+IdHeader header
 
 uint8 age
 float32 age_confidence

--- a/msg/StringIdStamped.msg
+++ b/msg/StringIdStamped.msg
@@ -1,0 +1,2 @@
+IdHeader header
+string data

--- a/package.xml
+++ b/package.xml
@@ -12,5 +12,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
   <depend>sensor_msgs</depend>
+  <depend>audio_common_msgs</depend>
 
 </package>


### PR DESCRIPTION
hri_msgs/IdHeader is similar to std_msgs/Header, but include
a 'id' field to associate the content of a message (eg, a region of
interest) to a 'resource' (eg a face, a body...)

This commit also includes several 'IdStamped' version of other ROS
messages, like ImageIdStamped, BoolIdStamped, etc.